### PR TITLE
Don't output an error about a missing tslint.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,9 +19,7 @@ function loadRelativeConfig() {
 	};
 	
 	var configPath = locateConfigFile("tslint.json", path.dirname(this.resourcePath));
-	if(typeof configPath !== "string") {		
-		console.log('tslint.json not found');		
-	} else {
+	if(typeof configPath == "string") {
 		this.addDependency(configPath);
 		var file = fs.readFileSync(configPath, "utf8");
 		options.configuration = JSON.parse(stripJsonComments(file));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-loader",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "tslint loader for webpack",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes #5 

Don't output an error about a missing tslint.json since it is optional.