### PR TITLE
Update TSLint to 3.0.0 and switch to peer dependency

### DIFF
--- a/formatters/customFormatter.js
+++ b/formatters/customFormatter.js
@@ -1,3 +1,5 @@
+var Lint = require("tslint/lib/lint");
+
 var __extends = this.__extends || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "loader-utils": "^0.2.7",
-    "strip-json-comments": "^1.0.2",
-    "typescript": "^1.6.0-beta"
+    "strip-json-comments": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-loader",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "tslint loader for webpack",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
     "url": "https://github.com/wbuchwalter/tslint-loader/issues"
   },
   "homepage": "https://github.com/wbuchwalter/tslint-loader",
+  "peerDependencies": {
+    "tslint": "^3.0.0"
+  },
   "dependencies": {
     "loader-utils": "^0.2.7",
     "strip-json-comments": "^1.0.2",
-    "tslint": "^2.5.0-beta",
     "typescript": "^1.6.0-beta"
   }
 }


### PR DESCRIPTION
@wbuchwalter This addresses #8.

* Tested locally via npm link and everything looks good
* Note that I also bumped the version of tslint-loader to 2.0.0 to maintain semantic versioning

I think all you need to do is merge and `npm publish`. :smile: 