### PR TITLE
Output errors in exception when bail is enabled in webapck

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,8 @@ function lint(input, options) {
     merge(options, this.options.tslint);
   }
 
+  var bailEnabled = (this.options.bail === true);
+
   //Override options in tslint.json by those passed to the loader as a query string
   var query = loaderUtils.parseQuery(this.query);
   merge(options, query);   
@@ -61,10 +63,10 @@ function lint(input, options) {
   var result = linter.lint();
   var emitter = options.emitErrors ? this.emitError : this.emitWarning;
 
-  report(result, emitter, options.failOnHint, options.fileOutput);
+  report(result, emitter, options.failOnHint, options.fileOutput, this.resourcePath,  bailEnabled);
 }
 
-function report(result, emitter, failOnHint, fileOutputOpts) {
+function report(result, emitter, failOnHint, fileOutputOpts, filename, bailEnabled) {
   if(result.failureCount === 0) return;    
   emitter(result.output);
 
@@ -72,8 +74,12 @@ function report(result, emitter, failOnHint, fileOutputOpts) {
     writeToFile(fileOutputOpts, result);
   }
 
-  if(failOnHint) {   
-    throw new Error("Compilation failed due to tslint errors.");
+  if(failOnHint) {
+    var messages = "";
+    if (bailEnabled){
+      messages = "\n\n" + filename + "\n" + result.output;
+    }
+    throw new Error("Compilation failed due to tslint errors." +  messages);
   }
 }
 


### PR DESCRIPTION
Addresses #18.

This PR allows the output of errors (actually only the first one encountered), only when 'bail' is enabled, when bail it not enabled, the errors will be reported by the normal emitting process.

Currently when 'bail' is enabled, the build will fail and not report the errors.

The bail option is required so that a non-zero exit status is reported for failures.