### PR TITLE
Fix merge function

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var path = require("path");
 var typescript = require("typescript");
 var mkdirp = require("mkdirp");
 var rimraf = require("rimraf");
+var objectAssign = require("object-assign");
 
 
 function loadRelativeConfig() {
@@ -120,25 +121,7 @@ function writeToFile(fileOutputOpts, result) {
 /* Merges two (or more) objects,
    giving the last one precedence */
 function merge(target, source) {   
-  if ( typeof target !== 'object' ) {
-    target = {};
-  }
-  
-  for (var property in source) {
-    if ( source.hasOwnProperty(property) ) {            
-      var sourceProperty = source[ property ];            
-      if ( typeof sourceProperty === 'object' ) {
-        target[ property ] = merge( target[ property ], sourceProperty );
-        continue;
-      }            
-      target[ property ] = sourceProperty;            
-    }        
-  }
-  
-  for (var a = 2, l = arguments.length; a < l; a++) {
-    merge(target, arguments[a]);
-  }
-  
+  objectAssign(target, source);
   return target;
 }
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "loader-utils": "^0.2.7",
     "mkdirp": "^0.5.1",
+    "object-assign": "^4.0.1",
     "rimraf": "^2.4.4",
     "strip-json-comments": "^1.0.2"
   }


### PR DESCRIPTION
Addresses https://github.com/wbuchwalter/tslint-loader/issues/21

In our project we need to define `rulesDirectory` option as array of directories in webpack configuration:
```
tslint: {
  rulesDirectory: ['path_1', 'path_2'],
  configuration: {...}
}
```
After merge into internal tslint options object array turns to weird object:
```
rulesDirectory: {
  '0': 'path_1',
  '1': 'path_2'
},
```
Tslint fails to load rules with this configuration as it expects array or string.
This PR fixes merge issue via [ES6 Object.assign() polyfill](https://www.npmjs.com/package/object-assign) that features [merging objects](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Merging_objects) functionality out of the box.