### PR TITLE
lint the original source file, not the (potentially transformed) stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function lint(input, options) {
   var query = loaderUtils.parseQuery(this.query);
   objectAssign(options, query);   
   
-  var linter = new Linter(this.resourcePath, input, options);
+  var linter = new Linter(this.resourcePath, fs.readFileSync(this.resourcePath, "utf8"), options);
   var result = linter.lint();
   var emitter = options.emitErrors ? this.emitError : this.emitWarning;
 


### PR DESCRIPTION
- allows tslint-loader to run as a postLoader
- otherwise you will be TSlinting Javascript
