### PR TITLE
Upgrading to tslint 4.0

### DIFF
--- a/formatters/customFormatter.js
+++ b/formatters/customFormatter.js
@@ -1,4 +1,4 @@
-var Lint = require("tslint/lib/lint");
+var Lint = require("tslint");
 
 var __extends = this.__extends || function (d, b) {
   for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
   Author William Buchwalter
   based on jshint-loader by Tobias Koppers
 */
-var Linter = require("tslint");
+var Lint = require("tslint");
 var tslintConfig = require("tslint/lib/configuration");
 var loaderUtils = require("loader-utils");
 var fs = require("fs");
@@ -18,7 +18,7 @@ function loadRelativeConfig() {
   var options = {
      formatter: "custom",
      formattersDirectory: __dirname + '/formatters/',
-     configuration: tslintConfig.findConfiguration(null, this.resourcePath)
+     configuration: tslintConfig.findConfiguration(null, this.resourcePath).results
   };
 
   return options;
@@ -29,15 +29,15 @@ function lint(input, options) {
   if(this.options.tslint) {
     objectAssign(options, this.options.tslint);
   }
-
+  var newLintOptions = { fix: false, formatter: "custom", formattersDirectory: __dirname + '/formatters/', rulesDirectory: '' };
   var bailEnabled = (this.options.bail === true);
 
   //Override options in tslint.json by those passed to the loader as a query string
   var query = loaderUtils.parseQuery(this.query);
   objectAssign(options, query);
 
-  var linter = new Linter(this.resourcePath, input, options);
-  var result = linter.lint();
+  var linter = new Lint.Linter(newLintOptions); linter.lint(this.resourcePath, input, options.configuration);
+  var result = linter.getResult();
   var emitter = options.emitErrors ? this.emitError : this.emitWarning;
 
   report(result, emitter, options.failOnHint, options.fileOutput, this.resourcePath,  bailEnabled);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "chai": "^3.5.0",
     "enhanced-resolve": "^2.3.0",
     "mocha": "^3.1.2",
-    "tslint": "^3.15.1",
+    "tslint": "^4.0.0",
     "typescript": "^2.0.10",
     "webpack": "^1.13.3"
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/wbuchwalter/tslint-loader",
   "peerDependencies": {
-    "tslint": "^3.0.0"
+    "tslint": "^4.0.0"
   },
   "dependencies": {
     "loader-utils": "^0.2.7",


### PR DESCRIPTION
`findConfiguration` now appends the configuration to `results`:
https://github.com/palantir/tslint/commit/5dff1711f397a7384c373ccba46ded961435a221. The usage of the linter changed a bit. For now I’m not
changing the amount of lines in the code since one of the tests is tied
to the current index file so please be mindful of the two statements in
the same line.