### PR TITLE
[FIX #46] Pass formatter and formattersDirectory options to Linter object

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function resolveOptions(webpackInstance) {
 }
 
 function lint(webpackInstance, input, options) {
-  var newLintOptions = { fix: false, formatter: 'custom', formattersDirectory: __dirname + '/formatters/', rulesDirectory: '' };
+  var newLintOptions = { fix: false, formatter: options.formatter || 'custom', formattersDirectory: options.formattersDirectory || __dirname + '/formatters/', rulesDirectory: '' };
   var bailEnabled = (webpackInstance.options.bail === true);
 
   var program;


### PR DESCRIPTION
This update will pass the `formatter` and `formattersDirectory` to tslint's Linter object.

### Example (webpack.config.js):
The configuration below will generate the correct report format.
```
tslint: {
        formatter: 'checkstyle',
        fileOutput: {
            dir: './reports/checkstyle',
            ext: 'xml',
            clean: true,
            header: '<?xml version="1.0" encoding="utf-8"?>\n<checkstyle version="5.7">',
            footer: '</checkstyle>'
        }
    }
```