### PR TITLE
Include dev version of tslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/wbuchwalter/tslint-loader",
   "peerDependencies": {
-    "tslint": "^4.0.0"
+    "tslint": "^4.0.0-dev"
   },
   "dependencies": {
     "loader-utils": "^0.2.7",


### PR DESCRIPTION
This allows to use dev versions of tslint with tslint-loader. You can test version constraint against tslint via https://semver.npmjs.com/

Closes #53