### PR TITLE
fix: update loader-utils dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function resolveFile(configPath) {
 
 function resolveOptions(webpackInstance) {
   var tslintOptions = webpackInstance.options.tslint ? webpackInstance.options.tslint : {};
-  var query = loaderUtils.parseQuery(webpackInstance.query);
+  var query = loaderUtils.getOptions(webpackInstance);
 
   var options = objectAssign({}, tslintOptions, query);
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "tslint": "^4.0.0"
   },
   "dependencies": {
-    "loader-utils": "^0.2.7",
+    "loader-utils": "^1.0.2",
     "mkdirp": "^0.5.1",
     "object-assign": "^4.1.1",
     "rimraf": "^2.4.4",
@@ -40,7 +40,7 @@
     "awesome-typescript-loader": "^3.0.3",
     "chai": "^3.5.0",
     "es6-promisify": "^5.0.0",
-    "eslint": "3.15.0",
+    "eslint": "^3.15.0",
     "mocha": "^3.2.0",
     "np": "^2.12.0",
     "tslint": "^4.4.2",


### PR DESCRIPTION
Currently using this loader gives a deprecation warning from the outdated loader-utils dependency