### PR TITLE
fix emitted errors & allow tslint@>=4.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,9 @@ function lint(webpackInstance, input, options) {
 
 function report(result, emitter, failOnHint, fileOutputOpts, filename, bailEnabled) {
   if (result.failureCount === 0) return;
-  emitter(result.output);
+  var err = new Error(result.output);
+  delete err.stack;
+  emitter(err);
 
   if (fileOutputOpts && fileOutputOpts.dir) {
     writeToFile(fileOutputOpts, result);
@@ -117,7 +119,7 @@ module.exports = function(input, map) {
   this.cacheable && this.cacheable();
   var callback = this.async();
 
-  if (!semver.satisfies(Lint.Linter.VERSION, '^4.0.0')) {
+  if (!semver.satisfies(Lint.Linter.VERSION, '>=4.0.0')) {
     throw new Error('Tslint should be of version 4+');
   }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/wbuchwalter/tslint-loader",
   "peerDependencies": {
-    "tslint": "^4.0.0"
+    "tslint": ">=4.0.0"
   },
   "dependencies": {
     "loader-utils": "^1.0.2",


### PR DESCRIPTION
Webpack now expects proper `Error` instances to be passed to `emitError()` & `emitWarning()`:
https://github.com/webpack/webpack/blob/master/lib/NormalModule.js#L112-L121

This looks like it wasn't an issue the last time the tests ran, but is blocking the other PRs (#68, #69) that are trying to fix the semver dep to allow `tslint@^5.0.0`