### PR TITLE
Fix empty warning reports with tslint 5.x.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ function lint(webpackInstance, input, options) {
 
 function report(result, emitter, failOnHint, fileOutputOpts, filename, bailEnabled) {
   if (result.failureCount === 0) return;
+  if (result.failures && result.failures.length === 0) return;
   var err = new Error(result.output);
   delete err.stack;
   emitter(err);


### PR DESCRIPTION
Seems like linter output api changed in tslint 5.x.x. Original condition kept, so that compatibility with 4.x.x is not broken.