### PR TITLE
Ref# 79 Fixes parsing of tslint.json (configuration)

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function parseConfigFile(webpackInstance, configFile, options) {
   }
 
   if (semver.satisfies(Lint.Linter.VERSION, '>=5.0.0')) {
-    return Lint.Configuration.parseConfigFile(options.configuration);
+    return Lint.Configuration.loadConfigurationFromPath(configFile,configFile);
   }
 
   return options.configuration;


### PR DESCRIPTION
Uses Lint.Configuration.loadConfigurationFromPath instead of
Lint.Configuration.parseConfigFile because the latter does not properly
resolve the “extends” directive in tslint configurations leaving the
runtime-resolved configuration without any of the inherited rules.