### PR TITLE
webpack-4.0.0-beta.2 compat: options deprecated

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function resolveFile(configPath) {
 }
 
 function resolveOptions(webpackInstance) {
-  var tslintOptions = webpackInstance.options.tslint ? webpackInstance.options.tslint : {};
+  var tslintOptions = webpackInstance.options && webpackInstance.options.tslint ? webpackInstance.options.tslint : {};
   var query = loaderUtils.getOptions(webpackInstance);
 
   var options = objectAssign({}, tslintOptions, query);
@@ -58,7 +58,7 @@ function lint(webpackInstance, input, options) {
     formattersDirectory: options.formattersDirectory,
     rulesDirectory: ''
   };
-  var bailEnabled = (webpackInstance.options.bail === true);
+  var bailEnabled = (webpackInstance.options && webpackInstance.options.bail === true);
 
   var program;
   if (options.typeCheck) {


### PR DESCRIPTION
Fixes #94 

I wanted to try out webpack-4.0.0-beta.2 to see if my bundle would build any faster.

Turns out `Compiler.options` is now deprecated so I check for it before using it. 

I was able to get some sweet ts-lint on my project after these 2 changes.

![image](https://user-images.githubusercontent.com/779325/36400997-7508bfa8-15a2-11e8-84c6-87483ff59279.png)
