### PR TITLE
Get custom tsconfig.json from the `tsConfigFile` option as the docs says

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,8 +26,8 @@ function resolveOptions(webpackInstance) {
 
   var options = objectAssign({}, tslintOptions, query);
 
-  var configFile = options.configFile
-    ? resolveFile(options.configFile)
+  var configFile = options.configFile || options.tsConfigFile
+    ? resolveFile(options.configFile || options.tsConfigFile)
     : null;
 
   options.formatter = options.formatter || 'custom';


### PR DESCRIPTION
Documentation in `README.md` says that the custom `tsconfig.json` is read by the `tsConfigFile` option, but it doesn't work because the code is trying to get it from `configFile` field of the options.

Enabled the `tsConfigFile` without changing the current one to provide compatibility with previous versions, but follow the documentation.

The `tsconfig.json` file is needed for rules that need type check, so it's something necessary to have working.