### PR TITLE
Pass in rulesDirectory to lint options

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function lint(webpackInstance, input, options) {
     fix: options.fix,
     formatter: options.formatter,
     formattersDirectory: options.formattersDirectory,
-    rulesDirectory: ''
+    rulesDirectory: options.rulesDirectory
   };
   var bailEnabled = (webpackInstance.options && webpackInstance.options.bail === true);
 


### PR DESCRIPTION
This is needed when we use rulesDirectory, right now it doesn't pass that value to tslint, adding this makes it correct.