### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Tslint loader for Webpack.
 
 :warning: __TSLint will be deprecated some time in 2019__. See this issue for more details: [Roadmap: TSLint &rarr; ESLint](https://github.com/palantir/tslint/issues/4534).   
-As such, users are also encouraged to migrate from tslint-loader to [eslint-loader ](https://github.com/webpack-contrib/eslint-loader)
+As such, users are also encouraged to migrate from tslint-loader to [eslint-webpack-plugin ](https://github.com/webpack-contrib/eslint-webpack-plugin)
 
 ## Installation
 


### PR DESCRIPTION
The current README.md file points to eslint-loader for migration which is deprecated.  
Changed the website link to eslint-webpack-plugin